### PR TITLE
解决多线程竞争问题

### DIFF
--- a/recovery/recover.go
+++ b/recovery/recover.go
@@ -38,6 +38,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"math/rand"
 )
 
 var log = logging.Logger("recover")
@@ -171,9 +172,10 @@ func RecoverSealedFile(ctx context.Context, rp export.RecoveryParams, parallel u
 				<-limiter
 			}()
 
+			randNum := rand.Intn(int(parallel) * 2)
 			//Control PC1 running interval
 			for {
-				if time.Now().Add(-time.Minute * 10).After(p1LastTaskTime) {
+				if time.Now().Add(-time.Minute * 10).Add(time.Duration(randNum) * time.Second).After(p1LastTaskTime) {
 					break
 				}
 				<-time.After(p1LastTaskTime.Sub(time.Now()))


### PR DESCRIPTION
在parallel较大时，会出现几个AP一起进行的情况，通过增加随机延时，可以减小这种情况出现的几率